### PR TITLE
fix: add write permissions to release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,9 @@ on: # yamllint disable-line rule:truthy
     tags:
       - '*-v*'
 
+permissions:
+  contents: write
+
 jobs:
   release:
     runs-on: macos-latest


### PR DESCRIPTION
- can't create a release otherwise