### PR TITLE
chore: add jumpstart 1st grade to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ And then tap this repository to install the available games:
 
 ```sh
 brew tap martimlobao/dos-games
+brew install --cask jumpstart-1st-grade
 brew install --cask ready-to-read-with-pooh
 ```
 


### PR DESCRIPTION
- add missing install instructions to Readme for jumpstart 1st grade